### PR TITLE
Fix Broken Links In Documentation

### DIFF
--- a/aws-gamekit-core/source/aws/gamekit/core/miniz.inc
+++ b/aws-gamekit-core/source/aws/gamekit/core/miniz.inc
@@ -2767,7 +2767,7 @@ mz_uint tdefl_create_comp_flags_from_zip_params(int level, int window_bits, int 
 #endif
 
 // Simple PNG writer function by Alex Evans, 2011. Released into the public domain: https://gist.github.com/908299, more context at
-// http://altdevblogaday.org/2011/04/06/a-smaller-jpg-encoder/.
+// https://web.archive.org/web/20110410100213/http://altdevblogaday.org/2011/04/06/a-smaller-jpg-encoder/
 void *tdefl_write_image_to_png_file_in_memory(const void *pImage, int w, int h, int num_chans, size_t *pLen_out)
 {
   tdefl_compressor *pComp = (tdefl_compressor *)MZ_MALLOC(sizeof(tdefl_compressor)); tdefl_output_buffer out_buf; int i, bpl = w * num_chans, y, z; mz_uint32 c; *pLen_out = 0;


### PR DESCRIPTION
There is a broken link http://altdevblogaday.org/2011/04/06/a-smaller-jpg-encoder/
in ```aws-gamekit-core/source/aws/gamekit/core/miniz.inc```. According to the internet archive, it has been dead since 2011. So I have replaced it with the internet archive link: https://web.archive.org/web/20110410100213/http://altdevblogaday.org/2011/04/06/a-smaller-jpg-encoder/

I found this links using [link-inspector](https://github.com/justindhillon/link-inspector) . If you find this PR useful, give the repo a ⭐

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
